### PR TITLE
Set encoding specified by the user instead of the hardcoded value (always ISO-8859-1)

### DIFF
--- a/sonar-jproperties-plugin/src/main/java/org/sonar/plugins/jproperties/JavaPropertiesSquidSensor.java
+++ b/sonar-jproperties-plugin/src/main/java/org/sonar/plugins/jproperties/JavaPropertiesSquidSensor.java
@@ -80,7 +80,7 @@ public class JavaPropertiesSquidSensor implements Sensor {
   public JavaPropertiesSquidSensor(FileSystem fileSystem, CheckFactory checkFactory, @Nullable CustomJavaPropertiesRulesDefinition[] customRulesDefinition) {
     this.fileSystem = fileSystem;
 
-    this.charset = Charset.forName("ISO-8859-1");
+    this.charset = fileSystem.encoding();
 
     this.mainFilePredicate = fileSystem.predicates().and(
       fileSystem.predicates().hasType(InputFile.Type.MAIN),


### PR DESCRIPTION
Hi,
We hit an error during analysis:

```
10:56:34 [ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar (default-cli) on project sonarqube-falsepositives: Unable to analyse file: /var/lib/jenkins/jobs/sonarqube-falsepositives/workspace/src/main/resources/messages_zh.properties: Unable to highlight file src/main/resources/messages_zh.properties: 12 is not a valid line offset for pointer. File src/main/resources/messages_zh.properties has 8 character(s) at line 3 -> [Help 1]
10:56:34 org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar (default-cli) on project sonarqube-falsepositives: Unable to analyse file: /var/lib/jenkins/jobs/sonarqube-falsepositives/workspace/src/main/resources/messages_zh.properties
...
10:56:34 Caused by: org.apache.maven.plugin.MojoExecutionException: Unable to analyse file: /var/lib/jenkins/jobs/sonarqube-falsepositives/workspace/src/main/resources/messages_zh.properties
...
10:56:34 Caused by: org.sonar.squidbridge.api.AnalysisException: Unable to analyse file: /var/lib/jenkins/jobs/sonarqube-falsepositives/workspace/src/main/resources/messages_zh.properties
...
10:56:34 Caused by: java.lang.IllegalArgumentException: Unable to highlight file src/main/resources/messages_zh.properties
...
10:56:34 Caused by: java.lang.IllegalArgumentException: 12 is not a valid line offset for pointer. File src/main/resources/messages_zh.properties has 8 character(s) at line 3
```

I analyzed the problem and found a reason why it has occurred. It is caused by an incorrect encoding. The plugin always parses files by using `ISO-8859-1`, but my sources are encoded in `UTF-8` (I set it by `<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>`).

After this small change files have been analyzed successfully.

You can test it by using the following file ([download zip](https://github.com/racodond/sonar-jproperties-plugin/files/1815260/messages_zh.zip)):
```


dummy=虚拟
```

Regards